### PR TITLE
Adding Dockerfile and CLI flag overrides

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,31 @@
-FROM debian:buster-slim AS build
+# syntax=docker/dockerfile:1
 
-# TODO: Docker support
+FROM golang:1.23 as builder
+
+# Set destination for COPY
+WORKDIR /app
+
+# Download Go modules
+COPY go.mod go.sum ./
+RUN go mod download
+
+# Copy the source code. Note the slash at the end, as explained in
+# https://docs.docker.com/reference/dockerfile/#copy
+COPY *.go ./
+
+# Build
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o ./go-gcsproxy
+
+FROM alpine:latest
+
+COPY --from=builder /app/go-gcsproxy /
+
+# Optional:
+# To bind to a TCP port, runtime parameters must be supplied to the docker command.
+# But we can document in the Dockerfile what ports
+# the application is going to listen on by default.
+# https://docs.docker.com/reference/dockerfile/#expose
+EXPOSE 9080
+
+# Run
+CMD ["/go-gcsproxy"]

--- a/config-helpers.go
+++ b/config-helpers.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"os"
+	"strconv"
+)
+
+func getStringEnvVar(key string) (string, bool) {
+	envVar := os.Getenv(key)
+	if len(envVar) == 0 {
+		return "", false
+	}
+	return envVar, true
+}
+
+func getBoolEnvVar(key string) (bool, bool) {
+	envVar, boolError := strconv.ParseBool(os.Getenv(key))
+	if boolError == nil {
+		return envVar, true
+	}
+	return false, false
+}
+
+func getIntEnvVar(key string) (int, bool) {
+	envVar, intError := strconv.Atoi(os.Getenv(key))
+	if intError == nil {
+		return envVar, true
+	}
+	return 0, false
+}

--- a/config-helpers.go
+++ b/config-helpers.go
@@ -5,26 +5,29 @@ import (
 	"strconv"
 )
 
-func getStringEnvVar(key string) (string, bool) {
+func setStringEnvVar(key string, defValue *string) int {
 	envVar := os.Getenv(key)
 	if len(envVar) == 0 {
-		return "", false
+		return 0
 	}
-	return envVar, true
+	*defValue = envVar
+	return 0
 }
 
-func getBoolEnvVar(key string) (bool, bool) {
+func setBoolEnvVar(key string, defValue *bool) int {
 	envVar, boolError := strconv.ParseBool(os.Getenv(key))
 	if boolError == nil {
-		return envVar, true
+		*defValue = envVar
+		return 0
 	}
-	return false, false
+	return 0
 }
 
-func getIntEnvVar(key string) (int, bool) {
+func setIntEnvVar(key string, defValue *int) int {
 	envVar, intError := strconv.Atoi(os.Getenv(key))
 	if intError == nil {
-		return envVar, true
+		*defValue = envVar
+		return 0
 	}
-	return 0, false
+	return 0
 }

--- a/main.go
+++ b/main.go
@@ -114,18 +114,43 @@ func main() {
 func loadConfig() *Config {
 	config := new(Config)
 
+	defaultSslInsecure := true
+	defaultCertPath := "/proxy/certs"
+	defaultDebug := 0
+	defaultKmsResourceName := "projects/ymail-central-logsink-0357/locations/global/keyRings/gcsproxy-test/cryptoKeys/gcsproxy-test-ring"
+
+	sslInsecure, sslInsecureOk := getBoolEnvVar("SSL_INSECURE")
+	if sslInsecureOk {
+		defaultSslInsecure = sslInsecure
+	}
+
+	certPath, certPathOk := getStringEnvVar("PROXY_CERT_PATH")
+	if certPathOk {
+		defaultCertPath = certPath
+	}
+
+	debug, debugOk := getIntEnvVar("DEBUG_LEVEL")
+	if debugOk {
+		defaultDebug = debug
+	}
+
+	kmsResourseName, kmsResourceNameOk := getStringEnvVar("GCP_KMS_RESOURCE_NAME")
+	if kmsResourceNameOk {
+		defaultKmsResourceName = kmsResourseName
+	}
+
 	flag.BoolVar(&config.version, "version", false, "show go-gcsproxy version")
 	flag.StringVar(&config.Addr, "addr", ":9080", "proxy listen addr")
 	flag.StringVar(&config.WebAddr, "web_addr", ":9081", "web interface listen addr")
-	flag.BoolVar(&config.SslInsecure, "ssl_insecure", true, "not verify upstream server SSL/TLS certificates.")
+	flag.BoolVar(&config.SslInsecure, "ssl_insecure", defaultSslInsecure, "not verify upstream server SSL/TLS certificates.")
 	flag.Var((*arrayValue)(&config.IgnoreHosts), "ignore_hosts", "a list of ignore hosts")
 	flag.Var((*arrayValue)(&config.AllowHosts), "allow_hosts", "a list of allow hosts")
-	flag.StringVar(&config.CertPath, "cert_path", "/Users/byronwhitlock/certs", "path to generated cert files")
-	flag.IntVar(&config.Debug, "debug", 2, "debug mode: 1 - print debug log, 2 - show debug from")
+	flag.StringVar(&config.CertPath, "cert_path", defaultCertPath, "path to generated cert files")
+	flag.IntVar(&config.Debug, "debug", defaultDebug, "debug mode: 1 - print debug log, 2 - show debug from")
 	flag.StringVar(&config.Dump, "dump", "", "dump filename")
 	flag.IntVar(&config.DumpLevel, "dump_level", 0, "dump level: 0 - header, 1 - header + body")
 	flag.StringVar(&config.Upstream, "upstream", "", "upstream proxy")
-	flag.StringVar(&config.KmsResourceName, "kms_project", "projects/ymail-central-logsink-0357/locations/global/keyRings/gcsproxy-test/cryptoKeys/gcsproxy-test-ring", "Payload will be encrypted with keys stored in KMS ")
+	flag.StringVar(&config.KmsResourceName, "kms_project", defaultKmsResourceName, "Payload will be encrypted with keys stored in KMS ")
 
 	flag.BoolVar(&config.UpstreamCert, "upstream_cert", false, "connect to upstream server to look up certificate details")
 	flag.Parse()

--- a/main.go
+++ b/main.go
@@ -119,25 +119,10 @@ func loadConfig() *Config {
 	defaultDebug := 0
 	defaultKmsResourceName := "projects/ymail-central-logsink-0357/locations/global/keyRings/gcsproxy-test/cryptoKeys/gcsproxy-test-ring"
 
-	sslInsecure, sslInsecureOk := getBoolEnvVar("SSL_INSECURE")
-	if sslInsecureOk {
-		defaultSslInsecure = sslInsecure
-	}
-
-	certPath, certPathOk := getStringEnvVar("PROXY_CERT_PATH")
-	if certPathOk {
-		defaultCertPath = certPath
-	}
-
-	debug, debugOk := getIntEnvVar("DEBUG_LEVEL")
-	if debugOk {
-		defaultDebug = debug
-	}
-
-	kmsResourseName, kmsResourceNameOk := getStringEnvVar("GCP_KMS_RESOURCE_NAME")
-	if kmsResourceNameOk {
-		defaultKmsResourceName = kmsResourseName
-	}
+	setBoolEnvVar("SSL_INSECURE", &defaultSslInsecure)
+	setStringEnvVar("PROXY_CERT_PATH", &defaultCertPath)
+	setIntEnvVar("DEBUG_LEVEL", &defaultDebug)
+	setStringEnvVar("GCP_KMS_RESOURCE_NAME", &defaultKmsResourceName)
 
 	flag.BoolVar(&config.version, "version", false, "show go-gcsproxy version")
 	flag.StringVar(&config.Addr, "addr", ":9080", "proxy listen addr")
@@ -154,6 +139,8 @@ func loadConfig() *Config {
 
 	flag.BoolVar(&config.UpstreamCert, "upstream_cert", false, "connect to upstream server to look up certificate details")
 	flag.Parse()
+
+	fmt.Printf("%+v\n", config)
 
 	return config
 }

--- a/main.go
+++ b/main.go
@@ -140,8 +140,6 @@ func loadConfig() *Config {
 	flag.BoolVar(&config.UpstreamCert, "upstream_cert", false, "connect to upstream server to look up certificate details")
 	flag.Parse()
 
-	fmt.Printf("%+v\n", config)
-
 	return config
 }
 


### PR DESCRIPTION
Adding a Dockerfile and a simple override structure for enabling environment variables for configuration parameters. Initial PR is only to expose (4) variables needed for controller setup, but it can be extended as appropriate for the remainder. As of now, this doesn't replace the existing CLI flag configs, but simply allows an alternative configuration.

The priority would be:

1. Defaults set as individual static variables in `loadConfig()`
2. Environment variables
3. CLI flags, which are the final decider and override all other settings

To extend this, do the following:

1. Verify that the type conversion logic in `config-helpers.go` has a function that supports the appropriate variable type that the Go app expects.
2. Create a "default" variable after the Config initialization in `loadConfig()`
3. Use the `set<TYPE>EnvVar` functions, pass in the `string` of the environment variable and a pointer to the default variable you created in step 2.
4. Replace the "default" in the CLI flag line with the default variable you created in step 2.
5. Let cool for 6 minutes. Season to taste. Serve and enjoy.