### PR TITLE
[OPTIONAL] Config readability adjustments and separated typing logic for environment variables

### DIFF
--- a/config-helpers.go
+++ b/config-helpers.go
@@ -5,29 +5,26 @@ import (
 	"strconv"
 )
 
-func setStringEnvVar(key string, defValue *string) int {
+func envConfigStringWithDefault(key string, defValue string) string {
 	envVar := os.Getenv(key)
 	if len(envVar) == 0 {
-		return 0
+		return defValue
 	}
-	*defValue = envVar
-	return 0
+	return envVar
 }
 
-func setBoolEnvVar(key string, defValue *bool) int {
+func envConfigBoolWithDefault(key string, defValue bool) bool {
 	envVar, boolError := strconv.ParseBool(os.Getenv(key))
 	if boolError == nil {
-		*defValue = envVar
-		return 0
+		return envVar
 	}
-	return 0
+	return defValue
 }
 
-func setIntEnvVar(key string, defValue *int) int {
+func envConfigIntWithDefault(key string, defValue int) int {
 	envVar, intError := strconv.Atoi(os.Getenv(key))
 	if intError == nil {
-		*defValue = envVar
-		return 0
+		return envVar
 	}
-	return 0
+	return defValue
 }

--- a/main.go
+++ b/main.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	rawLog "log"
 	"os"
-	"strconv"
 
 	"github.com/lqqyt2423/go-mitmproxy/addon"
 	"github.com/lqqyt2423/go-mitmproxy/proxy"
@@ -115,30 +114,11 @@ func main() {
 func loadConfig() *Config {
 	config := new(Config)
 
-	defaultSslInsecure := true
-	defaultCertPath := "/proxy/certs"
-	defaultDebug := 0
-	defaultKmsResourceName := ""
+	defaultSslInsecure := envConfigBoolWithDefault("SSL_INSECURE", true)
+	defaultCertPath := envConfigStringWithDefault("PROXY_CERT_PATH", "/proxy/certs")
+	defaultDebug := envConfigIntWithDefault("DEBUG_LEVEL", 0)
+	defaultKmsResourceName := envConfigStringWithDefault("GCP_KMS_RESOURCE_NAME", "")
 
-	sslInsecure, sslInsecureErr := strconv.ParseBool("SSL_INSECURE")
-	if sslInsecureErr == nil {
-		defaultSslInsecure = sslInsecure
-	}
-
-	certPath := os.Getenv("PROXY_CERT_PATH")
-	if certPath != "" {
-		defaultCertPath = certPath
-	}
-
-	debug, debugErr := strconv.Atoi(os.Getenv("DEBUG_LEVEL"))
-	if debugErr == nil {
-		defaultDebug = debug
-	}
-
-	kmsResourceName := os.Getenv("GCP_KMS_RESOURCE_NAME")
-	if kmsResourceName != "" {
-		defaultKmsResourceName = kmsResourceName
-	}
 	flag.BoolVar(&config.version, "version", false, "show go-gcsproxy version")
 	flag.StringVar(&config.Addr, "port", ":9080", "proxy listen addr")
 	flag.StringVar(&config.WebAddr, "web_port", ":9081", "web interface listen addr")


### PR DESCRIPTION
I wanted to finish some cleanup I had intended after the initial PR, but it looks like you'd already done some adjustments. Feel free to discard this if you prefer to keep the config setup as-is.

TL;DR; since typing logic is consistent for environment variables (i.e. always a string input with config expecting a typed output), I wanted to separate it out so we don't need repeated bespoke multi-line handlers for each individual environment variable. The original implementation was a placeholder, but I was able to clean this up into a set of functions that just take an environment variable string and a typed default and return the appropriate one. Reduces `loadconfig()` down to one line per default/environment variable, and both are tied together in the same function call for readability.

I chose to put the type handlers in a separate file (`config-helpers.go`), but I don't feel super strongly about where they live.