### PR TITLE
Update go proxy to work with python SDK API for simple and multipart Requests

### DIFF
--- a/gcs-proxy.go
+++ b/gcs-proxy.go
@@ -54,7 +54,7 @@ func InterceptGcsMethod(f *proxy.Flow) gcsMethod {
 				}
 			}
 		}
-		if strings.HasPrefix(f.Request.URL.Path, "/resumable/upload/storage/v1") {
+		if (strings.HasPrefix(f.Request.URL.Path, "/resumable/upload/storage/v1") || strings.HasPrefix(f.Request.URL.Path, "/upload/storage/v1")) {
 			if f.Request.Method == "POST" {
 				return resumableUploadPost
 			} else if f.Request.Method == "PUT" {
@@ -87,6 +87,7 @@ func (c *EncryptGcsPayload) Request(f *proxy.Flow) {
 
 	log.Debug(fmt.Sprintf("got request: %s", f.Request.Raw().RequestURI))
 	if IsEncryptDisabled() {
+		fmt.Println("Encryption Enabled: false")
 		return
 	}
 
@@ -132,6 +133,7 @@ func (c *DecryptGcsPayload) Response(f *proxy.Flow) {
 		log.Error(fmt.Errorf("got invalid response code! '%s' '%v'......\n\n%s", f.Request.URL, f.Response.StatusCode, f.Response.Body))
 	}
 	if IsEncryptDisabled() {
+		fmt.Println("Encryption Enabled: false")
 		return
 	}
 

--- a/gcs-proxy.go
+++ b/gcs-proxy.go
@@ -87,7 +87,6 @@ func (c *EncryptGcsPayload) Request(f *proxy.Flow) {
 
 	log.Debug(fmt.Sprintf("got request: %s", f.Request.Raw().RequestURI))
 	if IsEncryptDisabled() {
-		fmt.Println("Encryption Enabled: false")
 		return
 	}
 
@@ -133,7 +132,6 @@ func (c *DecryptGcsPayload) Response(f *proxy.Flow) {
 		log.Error(fmt.Errorf("got invalid response code! '%s' '%v'......\n\n%s", f.Request.URL, f.Response.StatusCode, f.Response.Body))
 	}
 	if IsEncryptDisabled() {
-		fmt.Println("Encryption Enabled: false")
 		return
 	}
 

--- a/handle-simple-download.go
+++ b/handle-simple-download.go
@@ -27,7 +27,7 @@ func HandleSimpleDownloadResponse(f *proxy.Flow) error {
 	}
 
 	log.Debug("#### Decryption OK:")
-	log.Debug(fmt.Println(string(unencryptedBytes)))
+	log.Debug(string(unencryptedBytes))
 
 	f.Response.Body = unencryptedBytes
 	contentLength := bytes.Count(unencryptedBytes, []byte{})


### PR DESCRIPTION
The PR contains changes in Go proxy to make successful calls from python client SDK API to send the simple upload and multipart GCS upload requests.

```
import os

import google.cloud.storage as storage

# Configure Google Cloud Storage
storage_client = storage.Client()

# Uncomment the following to test locally
os.environ["https_proxy"] = "http://127.0.0.1:9080"
os.environ["REQUESTS_CA_BUNDLE"] = "/proxy/certs/mitmproxy-ca-cert.pem"

bucket_name = "certs-proxy"
blob_name = "../data/10mb.txt"
destination_blob_name = "10mb-go-proxtest.txt"
bucket = storage_client.bucket(bucket_name)
blob = bucket.blob(destination_blob_name)
blob.upload_from_filename(blob_name)

print(f'File {blob_name} uploaded to {bucket_name}/{destination_blob_name}')
```