### PR TITLE
add dockerfile including go1.23.0 net/http patch

### DIFF
--- a/Dockerfile.go123patch
+++ b/Dockerfile.go123patch
@@ -1,0 +1,42 @@
+# syntax=docker/dockerfile:1
+
+FROM golang:1.23 as builder
+
+# Patching go std net/http
+COPY test/go-net-http-patch/transfer.go /tmp 
+RUN git clone https://github.com/golang/go.git /usr/local/go-src
+WORKDIR /usr/local/go-src
+RUN git checkout go1.23.0
+RUN cp /tmp/transfer.go ./src/net/http/transfer.go
+RUN cd ./src && ./make.bash
+
+# Add the patched Go binaries to PATHß
+ENV PATH /usr/local/go-src/bin:$PATH
+
+# Set destination for COPY
+WORKDIR /app
+
+# Download Go modules
+COPY go.mod go.sum ./
+# RUN go mod download
+
+# Copy the source code. Note the slash at the end, as explained in
+# https://docs.docker.com/reference/dockerfile/#copy
+COPY *.go ./
+
+# Build
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o ./go-gcsproxy
+
+FROM alpine:latest
+
+COPY --from=builder /app/go-gcsproxy /
+
+# Optional:
+# To bind to a TCP port, runtime parameters must be supplied to the docker command.
+# But we can document in the Dockerfile what ports
+# the application is going to listen on by default.
+# https://docs.docker.com/reference/dockerfile/#expose
+EXPOSE 9080
+
+# Run
+CMD ["/go-gcsproxy"]

--- a/test/client/test_axlearn_tf.py
+++ b/test/client/test_axlearn_tf.py
@@ -175,8 +175,8 @@ def test_tf_data_write_read(setup_data):
 
     assert sorted(expected["texts"]) == sorted(actual["texts"])
 
-#uncomment to skip if gcs proxy encryption is enabled
-#@pytest.mark.skip(reason="Not working with encryption yet.")
+# TODO b/384990452 proxy can't handle partial object donwload with encryption enabled
+@pytest.mark.skip(reason="Not working with encryption yet.")
 def test_tensorstore_orbax_write_read_pytree(setup_data):
     """Test case for orbax/tensortore - write jax pytree to GCS with ocdbt driver which orbax uses."""
     test_id = test_tensorstore_orbax_write_read_pytree.__name__


### PR DESCRIPTION
### Build docker image
`docker build --platform=linux/amd64 -f ./Dockerfile.go123patch  -t go-gcs-proxy .`

### Run docker container locally
`docker run -it -v /Users/ericshen/.config/gcloud:/usr/local/gcs-proxy/adc -v /Users/ericshen/apple-gcs-proxy:/usr/local/gcs-proxy/cert --env-file /Users/ericshen/gcs-proxy-poc/env/mitm-go-docker-env -p 9080:9080 --name go-gcs-proxy go-gcs-proxy`

### sample env file for the above docker run command
```
➜  env cat ~/gcs-proxy-poc/env/mitm-go-docker-env 
GCP_KMS_RESOURCE_NAME=projects/cool-machine-learning/locations/global/keyRings/proxy/cryptoKeys/proxy-kek
PROXY_CERT_PATH=/usr/local/gcs-proxy/cert
DEBUG_LEVEL=1
GOOGLE_APPLICATION_CREDENTIALS=/usr/local/gcs-proxy/adc/application_default_credentials.json
```