### PR TITLE
Add tests for byte range requests (prerequisite for fully resumable downloads)

### DIFF
--- a/proxy/gcs-proxy.go
+++ b/proxy/gcs-proxy.go
@@ -148,6 +148,7 @@ out:
 		break out
 	}
 	if err != nil {
+		f.Request.Body = nil // on error don't upload anything
 		log.Error(err)
 		return
 	}
@@ -196,6 +197,8 @@ out:
 
 	}
 	if err != nil {
+		f.Response.StatusCode = 500 // set the error to 500
+		f.Response.Body = []byte(err.Error())
 		log.Error(err)
 		return
 	}

--- a/proxy/handlers/handle-metadata-request.go
+++ b/proxy/handlers/handle-metadata-request.go
@@ -44,16 +44,14 @@ func HandleMetadataResponse(f *proxy.Flow) error {
 		gcsMetadataMap["size"] = customMetadata["x-unencrypted-content-length"]
 		gcsMetadataMap["md5Hash"] = customMetadata["x-md5Hash"]
 
-	} else {
-		return fmt.Errorf("unable to parse gcs metadata")
+		// Now write the gcs object metadata back to the multipart writer
+		jsonData, err := json.MarshalIndent(gcsMetadataMap, "", "\t")
+		if err != nil {
+			return fmt.Errorf("error marshalling gcsObjectMetadata: %v", err)
+		}
+		f.Response.Body = jsonData
+		log.Debug(fmt.Sprintf("rewrote metadata response: %s", f.Response.Body))
 	}
-	// Now write the gcs object metadata back to the multipart writer
-	jsonData, err := json.MarshalIndent(gcsMetadataMap, "", "\t")
-	if err != nil {
-		return fmt.Errorf("error marshalling gcsObjectMetadata: %v", err)
-	}
-	f.Response.Body = jsonData
-	log.Debug(fmt.Sprintf("rewrote metadata response: %s", f.Response.Body))
 
 	return nil
 }

--- a/test/regression/tests/test_byte_range_requests.bats
+++ b/test/regression/tests/test_byte_range_requests.bats
@@ -1,0 +1,123 @@
+load '../helpers/bats-support/load'
+load '../helpers/bats-assert/load'
+
+setup() {
+  export TESTFILE="byte-range-requests.txt"
+  # Create a temporary file with some content
+  echo "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ" > $TESTFILE
+}
+
+teardown() {
+  # Remove the temporary file
+  rm $TESTFILE
+}
+
+@test "Setup - gcloud storage cp" {
+  run gcloud storage cp $TESTFILE gs://$BUCKET/$TESTFILE 
+  assert_success
+}
+# Helper function to download a byte range using curl
+download_range() {
+  curl -s https://storage.googleapis.com/$BUCKET/$TESTFILE  \
+        -H "Range: bytes=$1-$2" \
+        -H "Authorization: Bearer $(gcloud auth print-access-token)" \
+        --cacert $CA_BUNDLE \
+        --proxy $HTTPS_PROXY
+}
+
+@test "GCS byte range: download first 10 bytes" {
+  
+  run download_range 0 10
+  assert_success
+  # Assuming your object contains predictable content, like "0123456789ABCDEF..."
+  assert_output "0123456789"
+}
+
+@test "GCS byte range: download middle range" {
+  skip
+
+  run download_range 5 14
+  assert_success
+  # Assuming your object contains predictable content
+  assert_output "56789ABCDE"
+}
+
+@test "GCS byte range: download last 10 bytes" {
+  skip
+
+  object_size=$(get_object_size)
+  start_byte=$((object_size - 10))
+  end_byte=$((object_size - 1))
+  run download_range $start_byte $end_byte
+  assert_success
+  # Assuming your object contains predictable content
+  # and that the object is at least 10 bytes long.
+  # If you do not know the content, you cannot assert the output.
+  # You could however, assert the length of the returned content.
+  run echo "$output" | wc -c
+  assert_output "10"
+}
+
+@test "GCS byte range: download single byte" {
+  skip
+
+  run download_range 5 5
+  assert_success
+  # Assuming your object contains predictable content
+  assert_output "5"
+}
+
+@test "GCS byte range: download from start to end (full object)" {
+  local object_size=$(wc -c < $TESTFILE)
+  object_size=$(xargs <<< $object_size)
+  
+  run download_range 0 $((object_size - 1))
+  assert_success
+  assert_output $(cat $TESTFILE)
+}
+
+@test "GCS byte range: download from specific byte to end" {
+  skip
+
+  object_size=$(wc -c $TESTFILE)
+  run download_range 5 "" #Download from byte 5 to the end.
+  assert_success
+  run gsutil cat gs://$BUCKET/$TESTFILE | tail -c $((object_size - 5)) > expected_content
+  run echo "$output" > actual_content
+  run diff expected_content actual_content
+  assert_success
+  rm expected_content actual_content
+}
+
+@test "GCS byte range: invalid range (start > end)" {
+  run download_range 10 5
+  assert_failure
+}
+
+@test "GCS byte range: invalid range (negative start)" {
+  run download_range -1 5
+  assert_failure
+}
+
+@test "GCS byte range: invalid range (negative end)" {
+  run download_range 0 -1
+  assert_failure
+}
+
+@test "GCS byte range: range beyond object size" {
+  local object_size=$(wc -c < $TESTFILE)
+  object_size=$(xargs <<< $object_size)
+
+  run download_range 0 $((object_size + 1000))
+  assert_success
+  run gsutil cat gs://$BUCKET/$TESTFILE > expected_content
+  run echo "$output" > actual_content
+  run diff expected_content actual_content
+  assert_success
+  rm expected_content actual_content
+}
+
+@test "Teardown - gcloud storage rm" {
+  run gcloud storage rm gs://$BUCKET/$TESTFILE
+  assert_success
+}


### PR DESCRIPTION
```
Updated property [core/custom_ca_certs_file].
test_byte_range_requests.bats
 ✓ Setup - gcloud storage cp
 ✓ GCS byte range: download first 10 bytes
 - GCS byte range: download middle range (skipped)
 - GCS byte range: download last 10 bytes (skipped)
 - GCS byte range: download single byte (skipped)
 ✓ GCS byte range: download from start to end (full object)
 - GCS byte range: download from specific byte to end (skipped)
 ✓ GCS byte range: invalid range (start > end)
 ✓ GCS byte range: invalid range (negative start)
 ✓ GCS byte range: invalid range (negative end)
 ✓ GCS byte range: range beyond object size
 ✓ Teardown - gcloud storage rm
test_gcloud_storage_cat.bats
 ✓ Test gcloud storage cp
 ✓ Test gcloud storage cat - returns exact object
 ✓ Test gcloud storage cat - returns correct byte length
 ✓ Test gcloud storage rm
test_gcs_metadata.bats
 ✓ Setup - gcloud storage cp
 ✓ Test GCS Metadata - verify content length
 ✓ Test GCS Metadata - verify md5 hash
 ✓ Test GCS Metadata - verify encryption-key
 ✓ Test GCS Metadata - verify proxy-version
 ✓ Teardown - gcloud storage rm
test_gsutil.bats
 ✓ Test gsutil cp
 ✓ Test gsutil cat - returns exact object
 ✓ Test gsutil cat - returns correct byte length
 ✓ Test gsutil rm
test_large_object_upload.bats
 ✓ Test 100MB Upload using gcloud
test_resumable_upload.bats
 - Test Single chunk upload - Step 1: POST (skipped)
 - Test Single chunk upload - Step 2: PUT (skipped)
 - Test gsutil rm (skipped)

30 tests, 0 failures, 7 skipped
```